### PR TITLE
Remove core_io.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ description = "An implementation of the XMODEM file-transfer protocol."
 edition = "2018"
 
 [dependencies]
-core_io = { version = "0.1", default-features = false, optional = true }
 log = { version = "^0.3", default-features = false }
 crc16 = "^0.3"
 
@@ -21,5 +20,3 @@ rand = "^0.3"
 [features]
 std = []
 default = ["std"]
-# XXX cargo#1839
-core = ["core_io"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,13 +310,12 @@ impl Xmodem {
 		dev: &mut D,
 		stream: &mut R,
 	) -> Result<usize> {
-		let bytes;
 		self.errors = 0;
 
 		debug!("Starting XMODEM transfer");
 		self.start_send(dev)?;
 		debug!("First byte received. Sending stream.");
-		bytes = self.send_stream(dev, stream)?;
+		let bytes = self.send_stream(dev, stream)?;
 		debug!("Sending EOT");
 		self.finish_send(dev)?;
 


### PR DESCRIPTION
Remove the dependency on `core_io` (and clean up a minor clippy lint).

Tested with nanobl-rs.